### PR TITLE
Add missing require

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const React = require('react');
+const _ = require('lodash');
 const sparkFactory = require('./spark');
 
 const Foo = React.createClass({


### PR DESCRIPTION
Without `const _ = require('lodash')`, I got an error:

```
Uncaught ReferenceError: _ is not defined
```

`_` is used at the line 21 of the same file.
https://github.com/gilbox/react-spark-scroll/blob/master/src/index.js#L21
