### PR TITLE
Remove event listeners on unmount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,12 @@ function factory(options) {
       } else {
         spark(element, () => element, this.props.timeline, this.props);
       }
+    },
+
+    componentWillUnmount() {
+        spark.cleanup();
     }
+
   });
 
   const SparkScroll = sparkScrollFactory('div');

--- a/src/spark.js
+++ b/src/spark.js
@@ -302,10 +302,18 @@ function sparkFactory({animator, formulas, actionProps, setup, invalidateAutomat
     window.addEventListener('resize', onInvalidate, false);
     eventEmitter.on('invalidate', onInvalidate);
 
+    eventEmitter.once('cleanup', function() {
+        window.removeEventListener('scroll', onScroll);
+        window.removeEventListener('resize', onInvalidate);
+        eventEmitter.removeListener('invalidate', onInvalidate)
+    });
+
     // delay parse a frame to allow proxy to render
     animationFrame.request(parseData.bind(null,timeline));
 
   };
+  
+  spark.cleanup = () => eventEmitter.emit('cleanup');
 
   spark.invalidate = () => eventEmitter.emit('invalidate');
 


### PR DESCRIPTION
Fix for issue https://github.com/gilbox/react-spark-scroll/issues/15

You might have a better way to do this. I was struggling to work out a way to expose the onScroll and onInvaldate functions so that I could remove them again. Using event emitter works
