### PR TITLE
Remove event listeners on unmounted components

### DIFF
--- a/src/spark.js
+++ b/src/spark.js
@@ -302,18 +302,15 @@ function sparkFactory({animator, formulas, actionProps, setup, invalidateAutomat
     window.addEventListener('resize', onInvalidate, false);
     eventEmitter.on('invalidate', onInvalidate);
 
-    eventEmitter.once('cleanup', function() {
-        window.removeEventListener('scroll', onScroll);
-        window.removeEventListener('resize', onInvalidate);
-        eventEmitter.removeListener('invalidate', onInvalidate)
-    });
+    spark.cleanup = () => {
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onInvalidate);
+      eventEmitter.removeListener('invalidate', onInvalidate);
+    };
 
     // delay parse a frame to allow proxy to render
     animationFrame.request(parseData.bind(null,timeline));
-
   };
-  
-  spark.cleanup = () => eventEmitter.emit('cleanup');
 
   spark.invalidate = () => eventEmitter.emit('invalidate');
 


### PR DESCRIPTION
This PR fixes the `cleanup` method being called for every components using `spark` every time a component is unmounted. Since it was emitting a `cleanup` event every time `componentWillUnmount` was called it would trigger every event listeners registered being removed from the `window` event queue.

Fixes #15.