### PR TITLE
Fix react-spark-scroll resolve path

### DIFF
--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -34,7 +34,7 @@ module.exports = {
 
   resolve: {
     alias: {
-      'react-spark-scroll': path.resolve(__dirname + '../../src/'),
+      'react-spark-scroll': path.resolve(__dirname, '../src'),
       'underscore': 'lodash'
     }
   },


### PR DESCRIPTION
When running examples it seems that *react-spark-scroll* alias wasn't resolve as expected 😭. Causing app to crash because paths to *spark-scroll-gsap* and *spark-scroll-rekapi* were wrong 🔧.