### PR TITLE
Update animation-frame dep to v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react": "0.14.x"
   },
   "dependencies": {
-    "animation-frame": "^0.2.4",
+    "animation-frame": "^0.3.0",
     "events": "^1.0.2",
     "lodash": "^4.11.0",
     "object-assign": "^2.0.0"


### PR DESCRIPTION
animation-frame v0.3.0 adds isomorphic support for serverside/non-browser rendering. See:  kof/animation-frame#25

I have been able to successfully use react-spark-scroll with the static site generator Webpack plugin (which renders React apps in nodejs as part of webpack compilation) after simply bumping this dependency version - seems like this was the main blocking issue for isomorphic rendering.